### PR TITLE
Adds support for CIM

### DIFF
--- a/source/PendingReboot.psd1
+++ b/source/PendingReboot.psd1
@@ -3,7 +3,7 @@
     RootModule = 'PendingReboot.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.0.1'
+    ModuleVersion = '1.0.0'
 
     # ID used to uniquely identify this module
     GUID = '7c868fa4-b23e-4994-b74a-e938aef933dd'

--- a/source/Private/Get-CimWmiData.ps1
+++ b/source/Private/Get-CimWmiData.ps1
@@ -1,0 +1,38 @@
+function Get-CimWmiData {
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [Hashtable]
+        $invokeWmiMethodParameters,
+
+        [Parameter()]
+        [Switch]
+        $Wmi
+    )
+
+    if ($Wmi) {
+        Invoke-WmiMethod @invokeWmiMethodParameters
+    }
+    else {
+        if ($invokeWmiMethodParameters.ArgumentList)
+        {
+            $invokeWmiMethodParameters.Arguments = @{
+                hDefKey     = $invokeWmiMethodParameters.ArgumentList[0]
+                sSubKeyName = $invokeWmiMethodParameters.ArgumentList[1]
+            }
+            if ($invokeWmiMethodParameters.Name -in ('GetStringValue', 'GetMultiStringValue'))
+            {
+                $invokeWmiMethodParameters.Arguments.sValueName = $invokeWmiMethodParameters.ArgumentList[2]
+            }
+            $invokeWmiMethodParameters.Remove('ArgumentList')
+        }
+
+        if ($invokeWmiMethodParameters.ComputerName -in ('.', 'localhost', $env:COMPUTERNAME))
+        {
+            $invokeWmiMethodParameters.Remove('ComputerName')
+        }
+
+        Invoke-CimMethod @invokeWmiMethodParameters
+    }
+}

--- a/source/Private/Get-CimWmiData.ps1
+++ b/source/Private/Get-CimWmiData.ps1
@@ -28,11 +28,6 @@ function Get-CimWmiData {
             $invokeWmiMethodParameters.Remove('ArgumentList')
         }
 
-        if ($invokeWmiMethodParameters.ComputerName -in ('.', 'localhost', $env:COMPUTERNAME))
-        {
-            $invokeWmiMethodParameters.Remove('ComputerName')
-        }
-
         Invoke-CimMethod @invokeWmiMethodParameters
     }
 }

--- a/source/Private/Invoke-CimWmiMethod.ps1
+++ b/source/Private/Invoke-CimWmiMethod.ps1
@@ -11,7 +11,7 @@ function Invoke-CimWmiMethod {
         $Wmi
     )
 
-    if ($PSBoundParameters.ContainsKey('Wmi'))
+    if ($Wmi)
     {
         Invoke-WmiMethod @invokeWmiMethodParameters
     }

--- a/source/Private/Invoke-CimWmiMethod.ps1
+++ b/source/Private/Invoke-CimWmiMethod.ps1
@@ -11,7 +11,8 @@ function Invoke-CimWmiMethod {
         $Wmi
     )
 
-    if ($Wmi) {
+    if ($PSBoundParameters.ContainsKey('Wmi'))
+    {
         Invoke-WmiMethod @invokeWmiMethodParameters
     }
     else {

--- a/source/Private/Invoke-CimWmiMethod.ps1
+++ b/source/Private/Invoke-CimWmiMethod.ps1
@@ -1,4 +1,4 @@
-function Get-CimWmiData {
+function Invoke-CimWmiMethod {
     [CmdletBinding()]
     param
     (

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -128,7 +128,11 @@ function Test-PendingReboot
 
         [Parameter()]
         [Switch]
-        $SkipPendingFileRenameOperationsCheck
+        $SkipPendingFileRenameOperationsCheck,
+
+        [Parameter()]
+        [Switch]
+        $Wmi
     )
 
     process
@@ -144,6 +148,10 @@ function Test-PendingReboot
                     ComputerName = $computer
                     ErrorAction  = 'Stop'
                 }
+                $getCimWmiDataParameters = @{
+                    Wmi                        = $Wmi
+                    invokeWmiMethodParameters = $invokeWmiMethodParameters
+                }
 
                 $hklm = [UInt32] "0x80000002"
 
@@ -154,32 +162,37 @@ function Test-PendingReboot
 
                 ## Query the Component Based Servicing Reg Key
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\')
-                $registryComponentBasedServicing = (Invoke-WmiMethod @invokeWmiMethodParameters).sNames -contains 'RebootPending'
+                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $registryComponentBasedServicing = $invokeResult.sNames -contains 'RebootPending'
 
                 ## Query WUAU from the registry
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\')
-                $registryWindowsUpdateAutoUpdate = (Invoke-WmiMethod @invokeWmiMethodParameters).sNames -contains 'RebootRequired'
+                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $registryWindowsUpdateAutoUpdate = $invokeResult.sNames -contains 'RebootRequired'
 
                 ## Query JoinDomain key from the registry - These keys are present if pending a reboot from a domain join operation
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Services\Netlogon')
-                $registryNetlogon = (Invoke-WmiMethod @invokeWmiMethodParameters).sNames
+                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $registryNetlogon = $invokeResult.sNames
                 $pendingDomainJoin = ($registryNetlogon -contains 'JoinDomain') -or ($registryNetlogon -contains 'AvoidSpnSet')
 
                 ## Query ComputerName and ActiveComputerName from the registry and setting the MethodName to GetMultiStringValue
-                $invokeWmiMethodParameters.Name = 'GetMultiStringValue'
+                $invokeWmiMethodParameters.Name = 'GetStringValue'
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\', 'ComputerName')
-                $registryActiveComputerName = Invoke-WmiMethod @invokeWmiMethodParameters
+                $registryActiveComputerName = Get-CimWmiData @getCimWmiDataParameters
 
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName\', 'ComputerName')
-                $registryComputerName = Invoke-WmiMethod @invokeWmiMethodParameters
+                $registryComputerName = Get-CimWmiData @getCimWmiDataParameters
 
                 $pendingComputerRename = $registryActiveComputerName -ne $registryComputerName -or $pendingDomainJoin
 
                 ## Query PendingFileRenameOperations from the registry
                 if (-not $PSBoundParameters.ContainsKey('SkipPendingFileRenameOperationsCheck'))
                 {
+                    $invokeWmiMethodParameters.Name = 'GetMultiStringValue'
                     $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager\', 'PendingFileRenameOperations')
-                    $registryPendingFileRenameOperations = (Invoke-WmiMethod @invokeWmiMethodParameters).sValue
+                    $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                    $registryPendingFileRenameOperations = $invokeResult.sValue
                     $registryPendingFileRenameOperationsBool = [bool]$registryPendingFileRenameOperations
                 }
 
@@ -193,7 +206,7 @@ function Test-PendingReboot
 
                     try
                     {
-                        $sccmClientSDK = Invoke-WmiMethod @invokeWmiMethodParameters
+                        $sccmClientSDK = Get-CimWmiData @getCimWmiDataParameters
                         $systemCenterConfigManager = $sccmClientSDK.ReturnValue -eq 0 -and ($sccmClientSDK.IsHardRebootPending -or $sccmClientSDK.RebootPending)
                     }
                     catch

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -150,7 +150,7 @@ function Test-PendingReboot
                     Name         = 'EnumKey'
                     ErrorAction  = 'Stop'
                 }
-                if ($PSBoundParameters.ContainsKey('Wmi'))
+                if ($Wmi)
                 {
                     $invokeWmiMethodParameters.ComputerName = $computer
                     if ($PSBoundParameters.ContainsKey('Credential'))
@@ -209,7 +209,7 @@ function Test-PendingReboot
                 $pendingComputerRename = $registryActiveComputerName -ne $registryComputerName -or $pendingDomainJoin
 
                 ## Query PendingFileRenameOperations from the registry
-                if (-not $PSBoundParameters.ContainsKey('SkipPendingFileRenameOperationsCheck'))
+                if (-not $SkipPendingFileRenameOperationsCheck)
                 {
                     $invokeWmiMethodParameters.Name = 'GetMultiStringValue'
                     $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager\', 'PendingFileRenameOperations')
@@ -219,7 +219,7 @@ function Test-PendingReboot
                 }
 
                 ## Query ClientSDK for pending reboot status, unless SkipConfigurationManagerClientCheck is present
-                if (-not $PSBoundParameters.ContainsKey('SkipConfigurationManagerClientCheck'))
+                if (-not $SkipConfigurationManagerClientCheck)
                 {
                     $invokeWmiMethodParameters.NameSpace = 'ROOT\ccm\ClientSDK'
                     $invokeWmiMethodParameters.Class = 'CCM_ClientUtilities'
@@ -245,7 +245,7 @@ function Test-PendingReboot
                     $systemCenterConfigManager -or `
                     $registryWindowsUpdateAutoUpdate
 
-                if ($PSBoundParameters.ContainsKey('Detailed'))
+                if ($Detailed)
                 {
                     [PSCustomObject]@{
                         ComputerName                     = $computer

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -161,10 +161,10 @@ function Test-PendingReboot
                 else {
                     if ($PSBoundParameters.ContainsKey('Credential'))
                     {
-                        if ($computer -notin ('.', 'localhost', $env:COMPUTERNAME)) {
-                            $NewCimSessionParameters = @{
-                                ComputerName = $computer
-                            }
+                        $NewCimSessionParameters = @{}
+                        if ($computer -notin ('.', 'localhost', $env:COMPUTERNAME))
+                        {
+                            $NewCimSessionParameters.ComputerName = $computer
                         }
                         $NewCimSessionParameters.Credential = $Credential
                         $invokeWmiMethodParameters.CimSession = (New-CimSession @NewCimSessionParameters)

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -201,10 +201,10 @@ function Test-PendingReboot
                 ## Query ComputerName and ActiveComputerName from the registry and setting the MethodName to GetMultiStringValue
                 $invokeWmiMethodParameters.Name = 'GetStringValue'
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\', 'ComputerName')
-                $registryActiveComputerName = Get-CimWmiData @getCimWmiDataParameters
+                $registryActiveComputerName = (Get-CimWmiData @getCimWmiDataParameters).sValue
 
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName\', 'ComputerName')
-                $registryComputerName = Get-CimWmiData @getCimWmiDataParameters
+                $registryComputerName = (Get-CimWmiData @getCimWmiDataParameters).sValue
 
                 $pendingComputerRename = $registryActiveComputerName -ne $registryComputerName -or $pendingDomainJoin
 

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -141,24 +141,46 @@ function Test-PendingReboot
         {
             try
             {
+                $getCimWmiDataParameters = @{
+                    Wmi = $Wmi
+                }
                 $invokeWmiMethodParameters = @{
                     Namespace    = 'root/default'
                     Class        = 'StdRegProv'
                     Name         = 'EnumKey'
-                    ComputerName = $computer
                     ErrorAction  = 'Stop'
                 }
-                $getCimWmiDataParameters = @{
-                    Wmi                        = $Wmi
-                    invokeWmiMethodParameters = $invokeWmiMethodParameters
+                if ($PSBoundParameters.ContainsKey('Wmi'))
+                {
+                    $invokeWmiMethodParameters.Add('ComputerName', $computer)
+                    if ($PSBoundParameters.ContainsKey('Credential'))
+                    {
+                        $invokeWmiMethodParameters.Credential = $Credential
+                    }
                 }
+                else {
+                    if ($PSBoundParameters.ContainsKey('Credential'))
+                    {
+                        if ($computer -notin ('.', 'localhost', $env:COMPUTERNAME)) {
+                            $NewCimSessionParameters = @{
+                                ComputerName = $computer
+                            }
+                        }
+                        $NewCimSessionParameters.Add('Credential', $Credential)
+                        $invokeWmiMethodParameters.Add('CimSession', (New-CimSession @NewCimSessionParameters))
+                    }
+                    else
+                    {
+                        if ($computer -notin ('.', 'localhost', $env:COMPUTERNAME))
+                        {
+                            $invokeWmiMethodParameters.Add('ComputerName', $computer)
+                        }
+                    }
+                }
+
+                $getCimWmiDataParameters.Add('invokeWmiMethodParameters', $invokeWmiMethodParameters)
 
                 $hklm = [UInt32] "0x80000002"
-
-                if ($PSBoundParameters.ContainsKey('Credential'))
-                {
-                    $invokeWmiMethodParameters.Credential = $Credential
-                }
 
                 ## Query the Component Based Servicing Reg Key
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\')

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -152,7 +152,7 @@ function Test-PendingReboot
                 }
                 if ($PSBoundParameters.ContainsKey('Wmi'))
                 {
-                    $invokeWmiMethodParameters.Add('ComputerName', $computer)
+                    $invokeWmiMethodParameters.ComputerName = $computer
                     if ($PSBoundParameters.ContainsKey('Credential'))
                     {
                         $invokeWmiMethodParameters.Credential = $Credential
@@ -166,19 +166,19 @@ function Test-PendingReboot
                                 ComputerName = $computer
                             }
                         }
-                        $NewCimSessionParameters.Add('Credential', $Credential)
-                        $invokeWmiMethodParameters.Add('CimSession', (New-CimSession @NewCimSessionParameters))
+                        $NewCimSessionParameters.Credential = $Credential
+                        $invokeWmiMethodParameters.CimSession = (New-CimSession @NewCimSessionParameters)
                     }
                     else
                     {
                         if ($computer -notin ('.', 'localhost', $env:COMPUTERNAME))
                         {
-                            $invokeWmiMethodParameters.Add('ComputerName', $computer)
+                            $invokeWmiMethodParameters.ComputerName = $computer
                         }
                     }
                 }
 
-                $getCimWmiDataParameters.Add('invokeWmiMethodParameters', $invokeWmiMethodParameters)
+                $getCimWmiDataParameters.invokeWmiMethodParameters = $invokeWmiMethodParameters
 
                 $hklm = [UInt32] "0x80000002"
 

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -141,7 +141,7 @@ function Test-PendingReboot
         {
             try
             {
-                $getCimWmiDataParameters = @{
+                $invokeCimWmiMethodParameters = @{
                     Wmi = $Wmi
                 }
                 $invokeWmiMethodParameters = @{
@@ -178,33 +178,33 @@ function Test-PendingReboot
                     }
                 }
 
-                $getCimWmiDataParameters.invokeWmiMethodParameters = $invokeWmiMethodParameters
+                $invokeCimWmiMethodParameters.invokeWmiMethodParameters = $invokeWmiMethodParameters
 
                 $hklm = [UInt32] "0x80000002"
 
                 ## Query the Component Based Servicing Reg Key
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\')
-                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @invokeCimWmiMethodParameters
                 $registryComponentBasedServicing = $invokeResult.sNames -contains 'RebootPending'
 
                 ## Query WUAU from the registry
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\')
-                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @invokeCimWmiMethodParameters
                 $registryWindowsUpdateAutoUpdate = $invokeResult.sNames -contains 'RebootRequired'
 
                 ## Query JoinDomain key from the registry - These keys are present if pending a reboot from a domain join operation
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Services\Netlogon')
-                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @invokeCimWmiMethodParameters
                 $registryNetlogon = $invokeResult.sNames
                 $pendingDomainJoin = ($registryNetlogon -contains 'JoinDomain') -or ($registryNetlogon -contains 'AvoidSpnSet')
 
                 ## Query ComputerName and ActiveComputerName from the registry and setting the MethodName to GetMultiStringValue
                 $invokeWmiMethodParameters.Name = 'GetStringValue'
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\', 'ComputerName')
-                $registryActiveComputerName = (Invoke-CimWmiMethod @getCimWmiDataParameters).sValue
+                $registryActiveComputerName = (Invoke-CimWmiMethod @invokeCimWmiMethodParameters).sValue
 
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName\', 'ComputerName')
-                $registryComputerName = (Invoke-CimWmiMethod @getCimWmiDataParameters).sValue
+                $registryComputerName = (Invoke-CimWmiMethod @invokeCimWmiMethodParameters).sValue
 
                 $pendingComputerRename = $registryActiveComputerName -ne $registryComputerName -or $pendingDomainJoin
 
@@ -213,7 +213,7 @@ function Test-PendingReboot
                 {
                     $invokeWmiMethodParameters.Name = 'GetMultiStringValue'
                     $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager\', 'PendingFileRenameOperations')
-                    $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
+                    $invokeResult = Invoke-CimWmiMethod @invokeCimWmiMethodParameters
                     $registryPendingFileRenameOperations = $invokeResult.sValue
                     $registryPendingFileRenameOperationsBool = [bool]$registryPendingFileRenameOperations
                 }
@@ -228,7 +228,7 @@ function Test-PendingReboot
 
                     try
                     {
-                        $sccmClientSDK = Invoke-CimWmiMethod @getCimWmiDataParameters
+                        $sccmClientSDK = Invoke-CimWmiMethod @invokeCimWmiMethodParameters
                         $systemCenterConfigManager = $sccmClientSDK.ReturnValue -eq 0 -and ($sccmClientSDK.IsHardRebootPending -or $sccmClientSDK.RebootPending)
                     }
                     catch

--- a/source/Public/Test-PendingReboot.ps1
+++ b/source/Public/Test-PendingReboot.ps1
@@ -184,27 +184,27 @@ function Test-PendingReboot
 
                 ## Query the Component Based Servicing Reg Key
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\')
-                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
                 $registryComponentBasedServicing = $invokeResult.sNames -contains 'RebootPending'
 
                 ## Query WUAU from the registry
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\')
-                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
                 $registryWindowsUpdateAutoUpdate = $invokeResult.sNames -contains 'RebootRequired'
 
                 ## Query JoinDomain key from the registry - These keys are present if pending a reboot from a domain join operation
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Services\Netlogon')
-                $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
                 $registryNetlogon = $invokeResult.sNames
                 $pendingDomainJoin = ($registryNetlogon -contains 'JoinDomain') -or ($registryNetlogon -contains 'AvoidSpnSet')
 
                 ## Query ComputerName and ActiveComputerName from the registry and setting the MethodName to GetMultiStringValue
                 $invokeWmiMethodParameters.Name = 'GetStringValue'
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\', 'ComputerName')
-                $registryActiveComputerName = (Get-CimWmiData @getCimWmiDataParameters).sValue
+                $registryActiveComputerName = (Invoke-CimWmiMethod @getCimWmiDataParameters).sValue
 
                 $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName\', 'ComputerName')
-                $registryComputerName = (Get-CimWmiData @getCimWmiDataParameters).sValue
+                $registryComputerName = (Invoke-CimWmiMethod @getCimWmiDataParameters).sValue
 
                 $pendingComputerRename = $registryActiveComputerName -ne $registryComputerName -or $pendingDomainJoin
 
@@ -213,7 +213,7 @@ function Test-PendingReboot
                 {
                     $invokeWmiMethodParameters.Name = 'GetMultiStringValue'
                     $invokeWmiMethodParameters.ArgumentList = @($hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager\', 'PendingFileRenameOperations')
-                    $invokeResult = Get-CimWmiData @getCimWmiDataParameters
+                    $invokeResult = Invoke-CimWmiMethod @getCimWmiDataParameters
                     $registryPendingFileRenameOperations = $invokeResult.sValue
                     $registryPendingFileRenameOperationsBool = [bool]$registryPendingFileRenameOperations
                 }
@@ -228,7 +228,7 @@ function Test-PendingReboot
 
                     try
                     {
-                        $sccmClientSDK = Get-CimWmiData @getCimWmiDataParameters
+                        $sccmClientSDK = Invoke-CimWmiMethod @getCimWmiDataParameters
                         $systemCenterConfigManager = $sccmClientSDK.ReturnValue -eq 0 -and ($sccmClientSDK.IsHardRebootPending -or $sccmClientSDK.RebootPending)
                     }
                     catch


### PR DESCRIPTION
Resolves #8. Should also fix #14 

In contrast to #13, this PR keeps the WMI functionality in place. And in general I tried to keep everything untouched as much as possible.

I added the CIM support as a default method, because WMI cmdlets have been deprecated for too long already. Therefore I suggest to bump the major version number, since in some environments this can be a breaking change.

I also fixed incorrect calls to `SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\` and `SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName\` - this is a regular string value: `GetMultiStringValue` doesn't return a difference even when the `ComputerName` values there are different.